### PR TITLE
Fix ready check on game page to check for a score instead

### DIFF
--- a/plugins/opencritic.py
+++ b/plugins/opencritic.py
@@ -6,7 +6,6 @@ from cloudbot import hook
 @hook.command('oc')
 def oc(text):
     url = 'http://api.opencritic.com/api/'
-    gameURL = url + 'game'
     searchURL = url + 'game/search'
     scoreURL = url +  'game/score'
 
@@ -29,13 +28,11 @@ def oc(text):
     'id': gameID
     }
 
-    response = requests.request("GET", gameURL, headers = headers, params = scoreQuery)
+    response = requests.request("GET", scoreURL, headers = headers, params = scoreQuery)
 
-    if response.json()['ready'] == True:
-        response = requests.request("GET", scoreURL, headers = headers, params = scoreQuery)
-
+    try:
         gameScore = math.ceil(float(response.json()['score']))
-
-        return '\x02{}\x02 - \x02Score:\x02 {} - {}'.format(gameTitle, gameScore, gameLink)
+    except:
+        return '\x02{}\x02 does not have an average score yet.'.format(gameTitle)
     else:
-        return '\x02{}\x02 has not yet been released.'.format(gameTitle)
+        return '\x02{}\x02 - \x02Score:\x02 {} - {}'.format(gameTitle, gameScore, gameLink)


### PR DESCRIPTION
Ready is optional in the API. Changing to a score-based check instead before passing a result.