### PR TITLE
Added !octop for top 5 games, changed math.ceil() to round()

### DIFF
--- a/plugins/opencritic.py
+++ b/plugins/opencritic.py
@@ -54,3 +54,32 @@ def octop(text):
         output.append('\x02{}\x02: {}'.format(i['name'], round(float(i['score']))))
 
     return ', '.join(output)
+
+@hook.command('ocup')
+def ocup(text):
+    url = 'http://api.opencritic.com/api/game/filter'
+
+    if text.lower() in {'switch', 'nintendo', 'nintendo switch'}:
+        text = '32'
+    elif text.lower() in {'sony', 'playstation', 'playstation 4', 'ps4', 'psn'}:
+        text = '6'
+    elif text.lower() in {'microsoft', 'ms', 'xbox', 'xbox one', 'xbox 1', 'xb1', 'xbl'}:
+        text = '7'
+    elif text.lower() in {'windows', 'pc'}:
+        text = '27'
+    
+    headers = {
+    'content-type': "application/json",
+    }
+
+    data = '{"Platforms": [' + text + '], "limit": 5, "orderBy": "timeAscending", "startDate": "2017-3-24", "minTime": true}'
+
+    output = []
+
+    response = requests.post(url, headers = headers, data = data)
+
+    for i in response.json():
+        output.append('\x02{}\x02: {}'.format(i['name'], i['releaseDate'][:10]))
+
+    return ', '.join(output)
+

--- a/plugins/opencritic.py
+++ b/plugins/opencritic.py
@@ -30,7 +30,7 @@ def oc(text):
     response = requests.request("GET", scoreURL, headers = headers, params = scoreQuery)
 
     try:
-        gameScore = math.ceil(float(response.json()['score']))
+        gameScore = round(float(response.json()['score']))
     except:
         return '\x02{}\x02 does not have an average score yet.'.format(gameTitle)
     else:

--- a/plugins/opencritic.py
+++ b/plugins/opencritic.py
@@ -1,5 +1,4 @@
 import requests
-import math
 
 from cloudbot import hook
 
@@ -36,3 +35,22 @@ def oc(text):
         return '\x02{}\x02 does not have an average score yet.'.format(gameTitle)
     else:
         return '\x02{}\x02 - \x02Score:\x02 {} - {}'.format(gameTitle, gameScore, gameLink)
+
+@hook.command('octop')
+def octop(text):
+    url = 'http://api.opencritic.com/api/game/filter'
+
+    headers = {
+    'content-type': "application/json",
+    }
+
+    data = '{"limit": 10, "orderBy": "score", "startDate": "2017-1-1"}'
+
+    output = []
+
+    response = requests.post(url, headers = headers, data = data)
+
+    for i in response.json():
+        output.append('\x02{}\x02: {}'.format(i['name'], round(float(i['score']))))
+
+    return ', '.join(output)

--- a/plugins/opencritic.py
+++ b/plugins/opencritic.py
@@ -44,7 +44,7 @@ def octop(text):
     'content-type': "application/json",
     }
 
-    data = '{"limit": 10, "orderBy": "score", "startDate": "2017-1-1"}'
+    data = '{"limit": 5, "orderBy": "score", "startDate": "2017-1-1"}'
 
     output = []
 

--- a/plugins/opencritic.py
+++ b/plugins/opencritic.py
@@ -1,4 +1,5 @@
 import requests
+import datetime
 
 from cloudbot import hook
 
@@ -68,11 +69,13 @@ def ocup(text):
     elif text.lower() in {'windows', 'pc'}:
         text = '27'
     
+    startDate = datetime.datetime.now()
+    
     headers = {
     'content-type': "application/json",
     }
 
-    data = '{"Platforms": [' + text + '], "limit": 5, "orderBy": "timeAscending", "startDate": "2017-3-24", "minTime": true}'
+    data = '{"Platforms": [' + text + '], "limit": 5, "orderBy": "timeAscending", "startDate": "' + str(startDate) + '-3-24", "minTime": true}'
 
     output = []
 
@@ -82,4 +85,5 @@ def ocup(text):
         output.append('\x02{}\x02: {}'.format(i['name'], i['releaseDate'][:10]))
 
     return ', '.join(output)
+    return startDate
 


### PR DESCRIPTION
Per vicious suggestion, round() is better used for the new command and to replace old one. !octop is a new command for top 5 games of the current year. Currently set to 2017, should probably be modified to generate the first day of the current year for rollover into 2018.