### PR TITLE
fix: python 3.10 compatibility and infinite reload loop

### DIFF
--- a/cloudbot/bot.py
+++ b/cloudbot/bot.py
@@ -239,7 +239,7 @@ class CloudBot:
         self.observer.start()
 
         # Connect to servers
-        yield from asyncio.gather(*[conn.try_connect() for conn in self.connections.values()], loop=self.loop)
+        yield from asyncio.gather(*[conn.try_connect() for conn in self.connections.values()])
 
         # Activate web interface.
         if self.config.get("web", {}).get("enabled", False) and web_installed:
@@ -364,5 +364,5 @@ class CloudBot:
                         break
 
         # Run the tasks
-        yield from asyncio.gather(*run_before_tasks, loop=self.loop)
-        yield from asyncio.gather(*tasks, loop=self.loop)
+        yield from asyncio.gather(*run_before_tasks)
+        yield from asyncio.gather(*tasks)

--- a/cloudbot/plugin.py
+++ b/cloudbot/plugin.py
@@ -128,12 +128,12 @@ class PluginManager:
         # But ignore files starting with _
         path_list = plugin_dir.rglob("[!_]*.py")
         # Load plugins asynchronously :O
-        yield from asyncio.gather(*[self.load_plugin(path) for path in path_list], loop=self.bot.loop)
+        yield from asyncio.gather(*[self.load_plugin(path) for path in path_list])
 
     @asyncio.coroutine
     def unload_all(self):
         yield from asyncio.gather(
-            *[self.unload_plugin(path) for path in self.plugins.keys()], loop=self.bot.loop
+            *[self.unload_plugin(path) for path in self.plugins.keys()]
         )
 
     @asyncio.coroutine

--- a/cloudbot/reloader.py
+++ b/cloudbot/reloader.py
@@ -111,5 +111,15 @@ class PluginEventHandler(ReloadHandler):
 
 
 class ConfigEventHandler(ReloadHandler):
-    def on_any_event(self, event):
+    def on_created(self, event):
+        self.loader.reload(event.src_path)
+
+    def on_deleted(self, event):
+        self.loader.reload(event.src_path)
+
+    def on_modified(self, event):
+        self.loader.reload(event.src_path)
+
+    def on_moved(self, event):
         self.loader.reload(getattr(event, "dest_path", event.src_path))
+


### PR DESCRIPTION
   1. Python 3.10 Compatibility: Removed the deprecated loop= keyword argument from all asyncio.gather calls in bot.py and plugin.py. This resolves the TypeError that was causing the crash.
   2. Infinite Reload Loop Fix: Updated reloader.py to use specific event handlers (on_modified, on_created, etc.) instead of on_any_event. This prevents the bot from re-triggering its own config reload every
      time it reads the file.
